### PR TITLE
Implement login flow with account creation and onboarding currency picker

### DIFF
--- a/AIFinanceApp/AIFinanceApp/Models/UserSettings.swift
+++ b/AIFinanceApp/AIFinanceApp/Models/UserSettings.swift
@@ -9,4 +9,9 @@ struct UserSettings {
 
 extension UserSettings {
     static let `default` = UserSettings(name: "User", currency: "USD", isDarkMode: false)
+
+    /// A predefined list of currencies supported by the app.
+    static let availableCurrencies = [
+        "USD", "EUR", "GBP", "JPY", "CAD", "AUD"
+    ]
 }

--- a/AIFinanceApp/AIFinanceApp/Services/AuthService.swift
+++ b/AIFinanceApp/AIFinanceApp/Services/AuthService.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Simple in-memory authentication service.
+final class AuthService {
+    private var users: [String: String] = [:] // username: password
+    private(set) var currentUser: String?
+
+    func createUser(username: String, password: String) -> Bool {
+        guard users[username] == nil else { return false }
+        users[username] = password
+        currentUser = username
+        return true
+    }
+
+    func login(username: String, password: String) -> Bool {
+        guard users[username] == password else { return false }
+        currentUser = username
+        return true
+    }
+
+    func logout() {
+        currentUser = nil
+    }
+}

--- a/AIFinanceApp/AIFinanceApp/ViewModels/AppViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/AppViewModel.swift
@@ -4,6 +4,7 @@ import Combine
 /// Global app state driving onboarding and subscription flow.
 final class AppViewModel: ObservableObject {
     @Published var userSettings: UserSettings = .default
+    @Published var isAuthenticated: Bool = false
     @Published var isOnboarded: Bool = false
     @Published var isSubscribed: Bool = false
 
@@ -11,6 +12,7 @@ final class AppViewModel: ObservableObject {
     @Published private(set) var balance: Double = 0
 
     private var cancellables = Set<AnyCancellable>()
+    private let authService = AuthService()
 
     init() {
         calculateBalance()
@@ -24,6 +26,26 @@ final class AppViewModel: ObservableObject {
 
     func subscribe() {
         isSubscribed = true
+    }
+
+    @discardableResult
+    func login(username: String, password: String) -> Bool {
+        let success = authService.login(username: username, password: password)
+        isAuthenticated = success
+        return success
+    }
+
+    @discardableResult
+    func createUser(username: String, password: String) -> Bool {
+        let success = authService.createUser(username: username, password: password)
+        isAuthenticated = success
+        return success
+    }
+
+    func logout() {
+        authService.logout()
+        isAuthenticated = false
+        isOnboarded = false
     }
 
     /// Calculates the total balance from sample data.

--- a/AIFinanceApp/AIFinanceApp/ViewModels/Auth/LoginViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Auth/LoginViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+
+/// Handles user login and account creation.
+final class LoginViewModel: ObservableObject {
+    @Published var username: String = ""
+    @Published var password: String = ""
+    @Published var confirmPassword: String = ""
+    @Published var errorMessage: String?
+
+    private let appViewModel: AppViewModel
+
+    init(appViewModel: AppViewModel) {
+        self.appViewModel = appViewModel
+    }
+
+    func login() {
+        guard appViewModel.login(username: username, password: password) else {
+            errorMessage = "Invalid credentials"
+            return
+        }
+    }
+
+    func createUser() {
+        guard password == confirmPassword else {
+            errorMessage = "Passwords do not match"
+            return
+        }
+        guard appViewModel.createUser(username: username, password: password) else {
+            errorMessage = "User already exists"
+            return
+        }
+    }
+}

--- a/AIFinanceApp/AIFinanceApp/Views/Auth/LoginView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Auth/LoginView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// A simple interface for user login and registration.
+struct LoginView: View {
+    @ObservedObject var viewModel: LoginViewModel
+    @State private var isCreatingAccount = false
+
+    var body: some View {
+        Form {
+            Section(header: Text(isCreatingAccount ? "Sign Up" : "Login")) {
+                TextField("Username", text: $viewModel.username)
+                SecureField("Password", text: $viewModel.password)
+                if isCreatingAccount {
+                    SecureField("Confirm Password", text: $viewModel.confirmPassword)
+                }
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundColor(.red)
+                }
+            }
+            Section {
+                Button(isCreatingAccount ? "Create Account" : "Login") {
+                    if isCreatingAccount {
+                        viewModel.createUser()
+                    } else {
+                        viewModel.login()
+                    }
+                }
+                Button(isCreatingAccount ? "Have an account? Log In" : "Need an account? Sign Up") {
+                    isCreatingAccount.toggle()
+                }
+            }
+        }
+        .navigationTitle(isCreatingAccount ? "Sign Up" : "Login")
+    }
+}
+
+#Preview {
+    LoginView(viewModel: LoginViewModel(appViewModel: AppViewModel()))
+}

--- a/AIFinanceApp/AIFinanceApp/Views/Home/HomeView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Home/HomeView.swift
@@ -7,6 +7,13 @@ struct HomeView: View {
     var body: some View {
         List {
             Section {
+                Picker("Currency", selection: $appViewModel.userSettings.currency) {
+                    ForEach(UserSettings.availableCurrencies, id: \.self) { currency in
+                        Text(currency).tag(currency)
+                    }
+                }
+                .pickerStyle(.menu)
+
                 Text("Balance: \(appViewModel.userSettings.currency) \(appViewModel.balance, specifier: "%.2f")")
                     .font(.headline)
 

--- a/AIFinanceApp/AIFinanceApp/Views/Onboarding/OnboardingView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Onboarding/OnboardingView.swift
@@ -7,7 +7,11 @@ struct OnboardingView: View {
         Form {
             Section(header: Text("Welcome")) {
                 TextField("Name", text: $viewModel.name)
-                TextField("Currency", text: $viewModel.currency)
+                Picker("Currency", selection: $viewModel.currency) {
+                    ForEach(UserSettings.availableCurrencies, id: \.self) { currency in
+                        Text(currency)
+                    }
+                }
             }
             Section {
                 Button("Continue") {

--- a/AIFinanceApp/AIFinanceApp/Views/RootView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/RootView.swift
@@ -6,7 +6,9 @@ struct RootView: View {
 
     var body: some View {
         NavigationStack {
-            if !appViewModel.isOnboarded {
+            if !appViewModel.isAuthenticated {
+                LoginView(viewModel: LoginViewModel(appViewModel: appViewModel))
+            } else if !appViewModel.isOnboarded {
                 OnboardingView(viewModel: OnboardingViewModel(appViewModel: appViewModel))
             } else if !appViewModel.isSubscribed {
                 PaywallView(viewModel: PaywallViewModel(appViewModel: appViewModel))

--- a/AIFinanceApp/AIFinanceApp/Views/Settings/SettingsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Settings/SettingsView.swift
@@ -7,7 +7,12 @@ struct SettingsView: View {
         Form {
             Section(header: Text("Profile")) {
                 TextField("Name", text: $viewModel.userSettings.name)
-                TextField("Currency", text: $viewModel.userSettings.currency)
+                Picker("Currency", selection: $viewModel.userSettings.currency) {
+                    ForEach(UserSettings.availableCurrencies, id: \.self) { currency in
+                        Text(currency).tag(currency)
+                    }
+                }
+                .pickerStyle(.menu)
             }
             Section(header: Text("Appearance")) {
                 Toggle("Dark Mode", isOn: $viewModel.userSettings.isDarkMode)

--- a/AIFinanceApp/AIFinanceApp/Views/Transactions/AddTransactionView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Transactions/AddTransactionView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Form used to create a new transaction.
+struct AddTransactionView: View {
+    @ObservedObject var viewModel: TransactionsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var merchant: String = ""
+    @State private var category: String = ""
+    @State private var amount: String = ""
+    @State private var date: Date = .now
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Merchant", text: $merchant)
+                TextField("Category", text: $category)
+                TextField("Amount", text: $amount)
+                    .keyboardType(.decimalPad)
+                DatePicker("Date", selection: $date, displayedComponents: .date)
+            }
+            .navigationTitle("Add Transaction")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(merchant.isEmpty || amount.isEmpty)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        let newTransaction = Transaction(
+            id: UUID(),
+            merchant: merchant,
+            category: category,
+            amount: Double(amount) ?? 0,
+            date: date,
+            tags: []
+        )
+        viewModel.add(newTransaction)
+        dismiss()
+    }
+}
+
+#Preview {
+    AddTransactionView(viewModel: TransactionsViewModel())
+}
+

--- a/AIFinanceApp/AIFinanceApp/Views/Transactions/TransactionsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Transactions/TransactionsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TransactionsView: View {
     @ObservedObject var viewModel: TransactionsViewModel
+    @State private var showingAddTransaction = false
 
     var body: some View {
         List {
@@ -11,7 +12,19 @@ struct TransactionsView: View {
             .onDelete(perform: viewModel.delete)
         }
         .navigationTitle("Transactions")
-        .toolbar { EditButton() }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                EditButton()
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showingAddTransaction = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingAddTransaction) {
+            AddTransactionView(viewModel: viewModel)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add in-memory auth service and login/sign-up screens
- gate app flow behind login before onboarding and main content
- use currency picker during onboarding

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4432398483248b0b2b6fde58b44c