### PR TITLE
Remove sample finance data

### DIFF
--- a/AIFinanceApp/AIFinanceApp/Models/Budget.swift
+++ b/AIFinanceApp/AIFinanceApp/Models/Budget.swift
@@ -9,9 +9,5 @@ struct Budget: Identifiable, Hashable {
 }
 
 extension Budget {
-    static let sample: [Budget] = [
-        Budget(id: UUID(), category: "Dining", limit: 200, spent: 45),
-        Budget(id: UUID(), category: "Groceries", limit: 500, spent: 120),
-        Budget(id: UUID(), category: "Entertainment", limit: 150, spent: 60)
-    ]
+    static let sample: [Budget] = []
 }

--- a/AIFinanceApp/AIFinanceApp/Models/Goal.swift
+++ b/AIFinanceApp/AIFinanceApp/Models/Goal.swift
@@ -10,8 +10,5 @@ struct Goal: Identifiable, Hashable {
 }
 
 extension Goal {
-    static let sample: [Goal] = [
-        Goal(id: UUID(), title: "Vacation", targetAmount: 1000, currentAmount: 250, dueDate: .now.addingTimeInterval(60*60*24*90)),
-        Goal(id: UUID(), title: "New Laptop", targetAmount: 1500, currentAmount: 300, dueDate: .now.addingTimeInterval(60*60*24*180))
-    ]
+    static let sample: [Goal] = []
 }

--- a/AIFinanceApp/AIFinanceApp/Models/Transaction.swift
+++ b/AIFinanceApp/AIFinanceApp/Models/Transaction.swift
@@ -12,9 +12,5 @@ struct Transaction: Identifiable, Hashable {
 
 extension Transaction {
     /// Sample transactions for previews and prototyping.
-    static let sample: [Transaction] = [
-        Transaction(id: UUID(), merchant: "Coffee Shop", category: "Dining", amount: 4.99, date: .now, tags: ["coffee"]),
-        Transaction(id: UUID(), merchant: "Grocery Store", category: "Groceries", amount: 82.30, date: .now.addingTimeInterval(-86400), tags: ["food"]),
-        Transaction(id: UUID(), merchant: "Movie Theater", category: "Entertainment", amount: 15.00, date: .now.addingTimeInterval(-172800), tags: ["fun"])
-    ]
+    static let sample: [Transaction] = []
 }

--- a/AIFinanceApp/AIFinanceAppTests/AIFinanceAppTests.swift
+++ b/AIFinanceApp/AIFinanceAppTests/AIFinanceAppTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class AIFinanceAppTests: XCTestCase {
     func testSampleDataCounts() {
-        XCTAssertEqual(SampleData.transactions.count, 3)
-        XCTAssertEqual(SampleData.budgets.count, 3)
-        XCTAssertEqual(SampleData.goals.count, 2)
+        XCTAssertEqual(SampleData.transactions.count, 0)
+        XCTAssertEqual(SampleData.budgets.count, 0)
+        XCTAssertEqual(SampleData.goals.count, 0)
     }
 }


### PR DESCRIPTION
## Summary
- remove hardcoded sample transactions, budgets and goals so the app starts with empty data
- update tests to expect empty initial datasets

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project AIFinanceApp/AIFinanceApp.xcodeproj -scheme AIFinanceApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ab785691c88324b7a87a8e30f5bc75