### PR TITLE
Refine login flow and add budgeting features

### DIFF
--- a/AIFinanceApp/AIFinanceApp/ViewModels/Auth/LoginViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Auth/LoginViewModel.swift
@@ -7,6 +7,7 @@ final class LoginViewModel: ObservableObject {
     @Published var password: String = ""
     @Published var confirmPassword: String = ""
     @Published var errorMessage: String?
+    @Published var isVerifying: Bool = false
 
     private let appViewModel: AppViewModel
 
@@ -15,6 +16,20 @@ final class LoginViewModel: ObservableObject {
     }
 
     func login() {
+        isVerifying = true
+        errorMessage = nil
+        defer { isVerifying = false }
+
+        guard !username.isEmpty else {
+            errorMessage = "Username required"
+            return
+        }
+
+        guard !password.isEmpty else {
+            errorMessage = "Password required"
+            return
+        }
+
         guard appViewModel.login(username: username, password: password) else {
             errorMessage = "Invalid credentials"
             return

--- a/AIFinanceApp/AIFinanceApp/ViewModels/Budgets/BudgetsViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Budgets/BudgetsViewModel.swift
@@ -9,4 +9,9 @@ final class BudgetsViewModel: ObservableObject {
             budgets[index] = budget
         }
     }
+
+    func add(category: String, limit: Double) {
+        let budget = Budget(id: UUID(), category: category, limit: limit, spent: 0)
+        budgets.append(budget)
+    }
 }

--- a/AIFinanceApp/AIFinanceApp/ViewModels/Goals/GoalsViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Goals/GoalsViewModel.swift
@@ -9,4 +9,9 @@ final class GoalsViewModel: ObservableObject {
             goals[index] = goal
         }
     }
+
+    func add(title: String, targetAmount: Double, dueDate: Date) {
+        let goal = Goal(id: UUID(), title: title, targetAmount: targetAmount, currentAmount: 0, dueDate: dueDate)
+        goals.append(goal)
+    }
 }

--- a/AIFinanceApp/AIFinanceApp/Views/Auth/LoginView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Auth/LoginView.swift
@@ -17,6 +17,9 @@ struct LoginView: View {
                     Text(error)
                         .foregroundColor(.red)
                 }
+                if viewModel.isVerifying {
+                    ProgressView()
+                }
             }
             Section {
                 Button(isCreatingAccount ? "Create Account" : "Login") {
@@ -26,6 +29,7 @@ struct LoginView: View {
                         viewModel.login()
                     }
                 }
+                .disabled(viewModel.isVerifying)
                 Button(isCreatingAccount ? "Have an account? Log In" : "Need an account? Sign Up") {
                     isCreatingAccount.toggle()
                 }

--- a/AIFinanceApp/AIFinanceApp/Views/Budgets/BudgetsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Budgets/BudgetsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct BudgetsView: View {
     @ObservedObject var viewModel: BudgetsViewModel
+    @State private var showingAddBudget = false
+    @State private var newCategory = ""
+    @State private var newLimit = ""
 
     var body: some View {
         List {
@@ -10,6 +13,29 @@ struct BudgetsView: View {
             }
         }
         .navigationTitle("Budgets")
+        .toolbar {
+            Button(action: { showingAddBudget = true }) {
+                Image(systemName: "plus")
+            }
+        }
+        .sheet(isPresented: $showingAddBudget) {
+            NavigationStack {
+                Form {
+                    TextField("Category", text: $newCategory)
+                    TextField("Limit", text: $newLimit)
+                        .keyboardType(.decimalPad)
+                    Button("Add") {
+                        if let limit = Double(newLimit) {
+                            viewModel.add(category: newCategory, limit: limit)
+                            showingAddBudget = false
+                            newCategory = ""
+                            newLimit = ""
+                        }
+                    }
+                }
+                .navigationTitle("New Budget")
+            }
+        }
     }
 }
 

--- a/AIFinanceApp/AIFinanceApp/Views/Goals/GoalsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Goals/GoalsView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct GoalsView: View {
     @ObservedObject var viewModel: GoalsViewModel
+    @State private var showingAddGoal = false
+    @State private var newTitle = ""
+    @State private var newTarget = ""
+    @State private var newDueDate = Date()
 
     var body: some View {
         List {
@@ -10,6 +14,31 @@ struct GoalsView: View {
             }
         }
         .navigationTitle("Goals")
+        .toolbar {
+            Button(action: { showingAddGoal = true }) {
+                Image(systemName: "plus")
+            }
+        }
+        .sheet(isPresented: $showingAddGoal) {
+            NavigationStack {
+                Form {
+                    TextField("Title", text: $newTitle)
+                    TextField("Target Amount", text: $newTarget)
+                        .keyboardType(.decimalPad)
+                    DatePicker("Due Date", selection: $newDueDate, displayedComponents: .date)
+                    Button("Add") {
+                        if let target = Double(newTarget) {
+                            viewModel.add(title: newTitle, targetAmount: target, dueDate: newDueDate)
+                            showingAddGoal = false
+                            newTitle = ""
+                            newTarget = ""
+                            newDueDate = Date()
+                        }
+                    }
+                }
+                .navigationTitle("New Goal")
+            }
+        }
     }
 }
 

--- a/AIFinanceApp/AIFinanceApp/Views/RootView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/RootView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Root view deciding whether to show onboarding, paywall or main app.
+/// Root view deciding whether to show onboarding or the main app.
 struct RootView: View {
     @StateObject private var appViewModel = AppViewModel()
 
@@ -10,8 +10,6 @@ struct RootView: View {
                 LoginView(viewModel: LoginViewModel(appViewModel: appViewModel))
             } else if !appViewModel.isOnboarded {
                 OnboardingView(viewModel: OnboardingViewModel(appViewModel: appViewModel))
-            } else if !appViewModel.isSubscribed {
-                PaywallView(viewModel: PaywallViewModel(appViewModel: appViewModel))
             } else {
                 MainTabView()
                     .environmentObject(appViewModel)

--- a/AIFinanceApp/AIFinanceApp/Views/Settings/SettingsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
+    @EnvironmentObject private var appViewModel: AppViewModel
 
     var body: some View {
         Form {
@@ -17,7 +18,10 @@ struct SettingsView: View {
             Section(header: Text("Appearance")) {
                 Toggle("Dark Mode", isOn: $viewModel.userSettings.isDarkMode)
             }
-            Section {
+            Section(header: Text("Subscription")) {
+                NavigationLink("Upgrade") {
+                    PaywallView(viewModel: PaywallViewModel(appViewModel: appViewModel))
+                }
                 Button("Restore Purchases") {}
             }
         }

--- a/AIFinanceApp/AIFinanceAppTests/AIFinanceAppTests.swift
+++ b/AIFinanceApp/AIFinanceAppTests/AIFinanceAppTests.swift
@@ -7,4 +7,18 @@ final class AIFinanceAppTests: XCTestCase {
         XCTAssertEqual(SampleData.budgets.count, 0)
         XCTAssertEqual(SampleData.goals.count, 0)
     }
+
+    func testAddBudget() {
+        let vm = BudgetsViewModel()
+        XCTAssertEqual(vm.budgets.count, 0)
+        vm.add(category: "Food", limit: 100)
+        XCTAssertEqual(vm.budgets.count, 1)
+    }
+
+    func testAddGoal() {
+        let vm = GoalsViewModel()
+        XCTAssertEqual(vm.goals.count, 0)
+        vm.add(title: "Vacation", targetAmount: 500, dueDate: Date())
+        XCTAssertEqual(vm.goals.count, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- streamline authentication flow and defer paywall to settings
- add forms to create new budgets and goals
- track login verification state to display progress and errors

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme AIFinanceApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79e4e8f48324b0f26108f6616e7d