### PR TITLE
Add asynchronous goal and budget management

### DIFF
--- a/AIFinanceApp/AIFinanceApp/Services/BudgetStore.swift
+++ b/AIFinanceApp/AIFinanceApp/Services/BudgetStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Actor responsible for managing budget data asynchronously.
+actor BudgetStore {
+    static let shared = BudgetStore()
+
+    private var budgets: [Budget] = SampleData.budgets
+
+    private init() {}
+
+    func fetchBudgets() -> [Budget] {
+        budgets
+    }
+
+    func add(_ budget: Budget) async {
+        budgets.append(budget)
+    }
+
+    func update(_ budget: Budget) async {
+        if let index = budgets.firstIndex(where: { $0.id == budget.id }) {
+            budgets[index] = budget
+        }
+    }
+
+    func delete(_ budget: Budget) async {
+        budgets.removeAll { $0.id == budget.id }
+    }
+}

--- a/AIFinanceApp/AIFinanceApp/Services/GoalStore.swift
+++ b/AIFinanceApp/AIFinanceApp/Services/GoalStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Actor responsible for managing goal data asynchronously.
+actor GoalStore {
+    static let shared = GoalStore()
+
+    private var goals: [Goal] = SampleData.goals
+
+    private init() {}
+
+    func fetchGoals() -> [Goal] {
+        goals
+    }
+
+    func add(_ goal: Goal) async {
+        goals.append(goal)
+    }
+
+    func update(_ goal: Goal) async {
+        if let index = goals.firstIndex(where: { $0.id == goal.id }) {
+            goals[index] = goal
+        }
+    }
+
+    func delete(_ goal: Goal) async {
+        goals.removeAll { $0.id == goal.id }
+    }
+}

--- a/AIFinanceApp/AIFinanceApp/ViewModels/Budgets/BudgetsViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Budgets/BudgetsViewModel.swift
@@ -1,12 +1,35 @@
 import Foundation
 
 /// Maintains the user's budget list and handles updates to individual budgets.
+@MainActor
 final class BudgetsViewModel: ObservableObject {
-    @Published var budgets: [Budget] = SampleData.budgets
+    @Published private(set) var budgets: [Budget] = []
+    private let store: BudgetStore
 
-    func update(budget: Budget) {
-        if let index = budgets.firstIndex(where: { $0.id == budget.id }) {
-            budgets[index] = budget
+    init(store: BudgetStore = .shared) {
+        self.store = store
+        Task { await loadBudgets() }
+    }
+
+    func loadBudgets() async {
+        budgets = await store.fetchBudgets()
+    }
+
+    func add(budget: Budget) async {
+        await store.add(budget)
+        await loadBudgets()
+    }
+
+    func update(budget: Budget) async {
+        await store.update(budget)
+        await loadBudgets()
+    }
+
+    func delete(at offsets: IndexSet) async {
+        for index in offsets {
+            let budget = budgets[index]
+            await store.delete(budget)
         }
+        await loadBudgets()
     }
 }

--- a/AIFinanceApp/AIFinanceApp/ViewModels/Home/HomeViewModel.swift
+++ b/AIFinanceApp/AIFinanceApp/ViewModels/Home/HomeViewModel.swift
@@ -1,17 +1,32 @@
 import Foundation
 
 /// Aggregates data for the dashboard and provides AI-generated insights.
+@MainActor
 final class HomeViewModel: ObservableObject {
     @Published var transactions: [Transaction] = SampleData.transactions
-    @Published var budgets: [Budget] = SampleData.budgets
-    @Published var goals: [Goal] = SampleData.goals
+    @Published private(set) var budgets: [Budget] = []
+    @Published private(set) var goals: [Goal] = []
     @Published var insight: String = ""
 
     private let insightsService: AIInsightsProviding
+    private let budgetStore: BudgetStore
+    private let goalStore: GoalStore
 
-    init(insightsService: AIInsightsProviding = AIInsightsService()) {
+    init(
+        insightsService: AIInsightsProviding = AIInsightsService(),
+        budgetStore: BudgetStore = .shared,
+        goalStore: GoalStore = .shared
+    ) {
         self.insightsService = insightsService
+        self.budgetStore = budgetStore
+        self.goalStore = goalStore
+        Task { await loadData() }
         fetchInsight()
+    }
+
+    func loadData() async {
+        budgets = await budgetStore.fetchBudgets()
+        goals = await goalStore.fetchGoals()
     }
 
     func fetchInsight() {

--- a/AIFinanceApp/AIFinanceApp/Views/Budgets/BudgetsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Budgets/BudgetsView.swift
@@ -2,17 +2,92 @@ import SwiftUI
 
 struct BudgetsView: View {
     @ObservedObject var viewModel: BudgetsViewModel
+    @State private var showingForm = false
+    @State private var editingBudget: Budget?
 
     var body: some View {
         List {
             ForEach(viewModel.budgets) { budget in
-                BudgetRow(budget: budget)
+                Button {
+                    editingBudget = budget
+                    showingForm = true
+                } label: {
+                    BudgetRow(budget: budget)
+                }
+            }
+            .onDelete { indexSet in
+                Task { await viewModel.delete(at: indexSet) }
             }
         }
         .navigationTitle("Budgets")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    editingBudget = nil
+                    showingForm = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingForm) {
+            BudgetFormView(budget: editingBudget) { budget in
+                Task {
+                    if viewModel.budgets.contains(where: { $0.id == budget.id }) {
+                        await viewModel.update(budget: budget)
+                    } else {
+                        await viewModel.add(budget: budget)
+                    }
+                }
+            }
+        }
     }
 }
 
 #Preview {
     BudgetsView(viewModel: BudgetsViewModel())
+}
+
+private struct BudgetFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var category: String
+    @State private var limit: String
+    let budget: Budget?
+    var onSave: (Budget) -> Void
+
+    init(budget: Budget? = nil, onSave: @escaping (Budget) -> Void) {
+        self.budget = budget
+        _category = State(initialValue: budget?.category ?? "")
+        _limit = State(initialValue: budget.map { String($0.limit) } ?? "")
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Category", text: $category)
+                TextField("Limit", text: $limit)
+                    .keyboardType(.decimalPad)
+            }
+            .navigationTitle(budget == nil ? "New Budget" : "Edit Budget")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        guard let limitValue = Double(limit) else { return }
+                        let newBudget = Budget(
+                            id: budget?.id ?? UUID(),
+                            category: category,
+                            limit: limitValue,
+                            spent: budget?.spent ?? 0
+                        )
+                        onSave(newBudget)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/AIFinanceApp/AIFinanceApp/Views/Goals/GoalsView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Goals/GoalsView.swift
@@ -2,14 +2,45 @@ import SwiftUI
 
 struct GoalsView: View {
     @ObservedObject var viewModel: GoalsViewModel
+    @State private var showingForm = false
+    @State private var editingGoal: Goal?
 
     var body: some View {
         List {
             ForEach(viewModel.goals) { goal in
-                GoalRow(goal: goal)
+                Button {
+                    editingGoal = goal
+                    showingForm = true
+                } label: {
+                    GoalRow(goal: goal)
+                }
+            }
+            .onDelete { indexSet in
+                Task { await viewModel.delete(at: indexSet) }
             }
         }
         .navigationTitle("Goals")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    editingGoal = nil
+                    showingForm = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingForm) {
+            GoalFormView(goal: editingGoal) { goal in
+                Task {
+                    if viewModel.goals.contains(where: { $0.id == goal.id }) {
+                        await viewModel.update(goal: goal)
+                    } else {
+                        await viewModel.add(goal: goal)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -33,4 +64,59 @@ struct GoalRow: View {
 
 #Preview {
     GoalsView(viewModel: GoalsViewModel())
+}
+
+private struct GoalFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String
+    @State private var targetAmount: String
+    @State private var currentAmount: String
+    @State private var dueDate: Date
+    let goal: Goal?
+    var onSave: (Goal) -> Void
+
+    init(goal: Goal? = nil, onSave: @escaping (Goal) -> Void) {
+        self.goal = goal
+        _title = State(initialValue: goal?.title ?? "")
+        _targetAmount = State(initialValue: goal.map { String($0.targetAmount) } ?? "")
+        _currentAmount = State(initialValue: goal.map { String($0.currentAmount) } ?? "0")
+        _dueDate = State(initialValue: goal?.dueDate ?? Date())
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Title", text: $title)
+                TextField("Target Amount", text: $targetAmount)
+                    .keyboardType(.decimalPad)
+                TextField("Current Amount", text: $currentAmount)
+                    .keyboardType(.decimalPad)
+                DatePicker("Due Date", selection: $dueDate, displayedComponents: .date)
+            }
+            .navigationTitle(goal == nil ? "New Goal" : "Edit Goal")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        guard
+                            let target = Double(targetAmount),
+                            let current = Double(currentAmount)
+                        else { return }
+                        let newGoal = Goal(
+                            id: goal?.id ?? UUID(),
+                            title: title,
+                            targetAmount: target,
+                            currentAmount: current,
+                            dueDate: dueDate
+                        )
+                        onSave(newGoal)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/AIFinanceApp/AIFinanceApp/Views/Home/HomeView.swift
+++ b/AIFinanceApp/AIFinanceApp/Views/Home/HomeView.swift
@@ -40,6 +40,9 @@ struct HomeView: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Dashboard")
+        .task {
+            await viewModel.loadData()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `BudgetStore` and `GoalStore` actors for async budget and goal persistence
- Update view models and home screen to load budgets and goals through async CRUD methods
- Add forms and deletion support for editing budgets and goals in the UI

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d99416c8324a8a4afbecec4c8f3